### PR TITLE
correct command name for people who don't use Ubuntu/Debian

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -158,8 +158,8 @@ cp "$GIT"/scripts/*.sh "$IPATH"
 UNAME=adsbexchange
 if ! id -u "${UNAME}" &>/dev/null
 then
-    # 2nd syntax is for fedora / centos
-    adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" || adduser --system --home-dir "$IPATH" --no-create-home "$UNAME"
+    # 2nd syntax is for fedora / centos / arch / everyone else
+    adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" || useradd --system --home-dir "$IPATH" --no-create-home "$UNAME"
 fi
 
 echo 4


### PR DESCRIPTION
Ubuntu's commands and structure are starting to merge with other distributions, so this might not even be necessary as an "alternate" command, per se, but in any case, the correct command for fedora/centos/arch/everyone who isn't debian based has always been `useradd`

This single change enabled this feedclient to install properly without hiccups on my headless Arch Ryzen server.