### PR TITLE
update: use `useradd` as fallback

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -159,7 +159,12 @@ UNAME=adsbexchange
 if ! id -u "${UNAME}" &>/dev/null
 then
     # 2nd syntax is for fedora / centos
-    adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" || adduser --system --home-dir "$IPATH" --no-create-home "$UNAME"
+    if command -v adduser &> /dev/null
+    then
+        adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" || adduser --system --home-dir "$IPATH" --no-create-home "$UNAME"
+    else
+        useradd --system --home "$IPATH" --no-create-home "$UNAME"
+    fi
 fi
 
 echo 4


### PR DESCRIPTION
On some systems (arch), `adduser` doesn't exist and the install script fails. Fallback to `useradd` if the foremost doesn't exist.

I guess `adduser` could be removed and we don't create the home, etc., but I'm not a Debian expert.